### PR TITLE
Update homepage.dart

### DIFF
--- a/4 Weather API App/flutter_weather_api_app/lib/views/homepage/homepage.dart
+++ b/4 Weather API App/flutter_weather_api_app/lib/views/homepage/homepage.dart
@@ -45,7 +45,7 @@ class HomePage extends StatelessWidget {
                         Provider.of<HomePageController>(context, listen: false)
                             .getBasicDataByCityName(
                                 city: _textEditingController.text);
-                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                        Scaffold.of(context).showSnackBar(SnackBar(
                           content: Text("Fetching Articles"),
                           backgroundColor: Colors.yellow[100],
                         ));


### PR DESCRIPTION
No ScaffoldMessenger widget found.

Scaffold widgets require a ScaffoldMessenger widget ancestor.
Usually, the ScaffoldMessenger widget is presented by the MaterialApp
at the top of the widget tree.

Code after migration:

`ScaffoldMessenger.of(context).showSnackBar(mySnackBar);
`

-

Code before migration:

`Scaffold.of(context).showSnackBar(mySnackBar);
`
